### PR TITLE
Fix urls and ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ lib-ml
 model-training
 (all other repos are filled with wrappers)
 
+## Overview A3
+
+## Docker Compose
+
+To test the predict:
+```
+curl --header "Content-Type: application/json" --request POST --data '{"url": ["google.com", "tudelft.nl"]}'  http://localhost:5000/predict
+```
+
 # Vagrant
 To run the setup for creating and provisioning VMs with Vagrant and Ansible, you need to have Vagrant (https://developer.hashicorp.com/vagrant/install), Ansible (pip install ansible) and VirtualBox (https://www.virtualbox.org/wiki/Downloads) installed.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ services:
   model-service:
     image: ghcr.io/remla24-team8/model-service:v0.1.0
     container_name: model-service
-    ports:
-      - "4000:5000"
     volumes:
         - model-service-model-volume:/model-service/models
 
@@ -14,7 +12,7 @@ services:
       retries: 15
 
   app-backend:
-    image: ghcr.io/remla24-team8/app-backend:3702638
+    image: ghcr.io/remla24-team8/app-backend:main
     container_name: app-backend
     depends_on:
      model-service:
@@ -22,18 +20,18 @@ services:
     ports:
       - "127.0.0.1:5000:5000"
     environment:
-      MODEL_SERVICE_URL: 'http://model-service:4000'
+      MODEL_SERVICE_URL: 'http://model-service:5000'
       
   app-frontend:
-    image: ghcr.io/remla24-team8/app-frontend:eb76721
+    image: ghcr.io/remla24-team8/app-frontend:main
     container_name: app-frontend
     depends_on:
      model-service:
        condition: service_healthy
     ports:
-      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:3000:80"
     environment:
-      REACT_APP_BACKEND_URL: 'http://app-backend:5000'
+      BACKEND_URL: 'http://localhost:5000'
 
 volumes:
   model-service-model-volume:


### PR DESCRIPTION
This changes the frontend to not call via the Docker network (because that won't be available in the browser) but just localhost. It also ensures that the backend calls the model service via the Docker network to use the right port. This also removes exposing the model service directly, it's only available inside the Docker network. I also use the right tags.